### PR TITLE
(Do not merge) Example of how to add term frequencies

### DIFF
--- a/hmpps_person_match_score/match.py
+++ b/hmpps_person_match_score/match.py
@@ -90,6 +90,13 @@ def score(data):
     )
     linker.load_settings_from_json(model_path)
 
+    tf_table_names = [
+        {"forename1_std": "robin", "tf_first_name": 0.0002},
+        {"forename1_std": "john", "tf_first_name": 0.01},
+        {"forename1_std": "lily", "tf_first_name": 0.0033},
+    ]
+    linker.register_term_frequency_table(tf_table_names)
+
     # Make predictions
     json_output = linker.predict().as_pandas_dataframe().to_json()
 

--- a/hmpps_person_match_score/model.json
+++ b/hmpps_person_match_score/model.json
@@ -60,7 +60,8 @@
                     "sql_condition": "forename1_std_l = forename1_std_r",
                     "label_for_charts": "Exact match",
                     "m_probability": 0.9311633543815533,
-                    "u_probability": 0.004366147260641869
+                    "u_probability": 0.004366147260641869,
+                    "tf_adjustment_column": "forename1_std"
                 },
                 {
                     "sql_condition": "levenshtein(forename1_std_l, forename1_std_r) <= 2",


### PR DESCRIPTION
This illustrates how term frequencies adjustments can be enabled

At the moment i've just hard coded the data.

<details>
<summary>
example of use
</summary>

```python
import pandas as pd

from hmpps_person_match_score import standardisation_functions
from hmpps_person_match_score.match import score

valid_sample = {
    "unique_id": {"0": "861", "1": "862"},
    "first_name": {"0": "Lily", "1": "Lily"},
    "surname": {"0": "Robinson", "1": "Robibnson"},
    "dob": {"0": "2009-07-06", "1": "2009-07-06"},
    "pnc_number": {
        "0": "2001/0141640Y",
        "1": None,
    },
    "source_dataset": {"0": "libra", "1": "delius"},
}


data = pd.DataFrame(valid_sample)

data = standardisation_functions.standardise_pnc_number(data, pnc_col="pnc_number")
data = standardisation_functions.standardise_dob(data, dob_col="dob")
data = standardisation_functions.standardise_names(
    data, name_cols=["first_name", "surname"]
)
data = standardisation_functions.fix_zero_length_strings(data)

# If no source dataset provided assume it's in the same format we expect,
# our algorithm does not need to know which record is which
# so this is just a formality
if len(data["source_dataset"]) == 0:
    data["source_dataset"] = pd.Series({"0": "libra", "1": "delius"})
    data["source_dataset"] = data["source_dataset"].astype("str")

score(data)

```

</details>


I have previously mentioned that a challenge here is that `hmpps-person-match-score` is stateless,  json goes in, json comes out.  No external database connections are required. No persistent database connection is needed between calls.

If you have a big term frequency table, it will take time to load in, meaning that it's too slowto do it 'on the fly' when `match()` is called.

A solution for this is to set up a persistent duckdb database connection when the app starts up.  Term frequency tables could be loaded e.g. from parquet on startup, and for this connection to be reused amongst calls.

However, this PR illustrates a different approach is possible whereby:
- tf tables are stored in postgres
- the caller of the API (kotlin) pulls the specific term frequencies and includes in the data it POSTs.  In the above example, that means performing a lookup on `lily` in postgres, and sending `match()` some json like `{"forename1_std": "lily", "tf_first_name": 0.0033}`.
- this term frequency 'table' is then loaded into duckdb in real time.  this is almost instantaneous

in this way:
- the entire app can remain stateless, 
- we no longer have to store data in loads of different places
- tf tables are arguably easier to update
- the match score app doesn't need any connection to postgres


For reference, here's an older message I sent in Slack on this topic:

<details>
Gary mentioned the three options you’ve been considering for running Splink scores from Kotlin.  Sounds like we’ll chat about this next week, but thought Id jot down some thoughts in advance of discussion.  The options (i think) are:

1. Shell out to Python
2. HTTP API, using `hmpps-person-match-score`=HPMS as a starting point
3. Hard code sql

One challenge around (2), is term freqency tables.  HPMS is stateless - json goes in, json comes out.  No external database connections are required.

That changes if you need term frequency tables.  These need to be made available to Splink, which means either:
* HPMS needs a database connection
* HMPS computes them on the fly, or loads this data in from e.g. a csv file.  But then you take a big performance hit because, in the current architecture where a Splink session is created anew for each API call, this needs to be done on each API call, or else you need to maintain the initialised Splink/python session and the code is no longer stateless 

It actually gets a little more complicated than that because HMPS uses the duckdb databsae engine.  Luckily the a [postgres extension](https://duckdb.org/docs/extensions/postgres.html) exists that allows you to attach postgres tables to the databse.  So maybe that’s a promising route.  But it’s not one I’ve actually tried before.

Under the hood, duckdb will have to do a join between the incoming json data, and the attached postgres table, and I’m not sure what the performance of that is like.  The docs say:

> It might be desirable to create a copy of the Postgres databases in DuckDB to prevent the system from re-reading the tables from Postgres continuously, particularly for large tables

A final option would be to execute the SQL linkage against postgres itself, but a downside is that postgres doesn’t have great support for the fuzzy matching functions used by Splink.

Maybe none of this is too bad because we can modify `hmpps-person-match-score` to init the term frequency tables on start up (e.g. read from postgres, or a csv file, or compute), and then maintain a live Splink session between API calls.  not sure
</details>
