### PR TITLE
CPR-425 Increase Workers and Timeout

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,4 +3,4 @@ set -e
 
 source /opt/pysetup/.venv/bin/activate
 
-exec gunicorn --bind 0.0.0.0:5000 --forwarded-allow-ips='*' wsgi:app
+exec gunicorn --bind 0.0.0.0:5000 --forwarded-allow-ips='*' wsgi:app --workers 4 --timeout 600


### PR DESCRIPTION
Seeing: ```[2024-08-30 09:03:16 +0000] [1] [ERROR] Worker (pid:1893) was sent SIGKILL! Perhaps out of memory?
[2024-08-30 09:03:16 +0000] [1922] [INFO] Booting worker with pid: 1922 ```

Increase timeout to also ML model to dump and clear data