### PR TITLE
Addressing Memory Build-up in DuckDB Due to Unused Tables

### DIFF
--- a/hmpps_person_match_score/views/match_view.py
+++ b/hmpps_person_match_score/views/match_view.py
@@ -99,8 +99,11 @@ class MatchView(BaseView):
         )
         linker.load_settings(self.get_model_path(SplinkModels.MODEL))
 
-        # Make predictions
-        json_output = linker.predict().as_pandas_dataframe().to_json()
+        prediction = linker.predict()
 
-        # Return
+        json_output = prediction.as_pandas_dataframe().to_json()
+
+        # manually clean up prediction table from db to avoid OOM, see PR 163
+        linker._delete_table_from_database(prediction.physical_name)  # noqa: SLF001
+
         return json.loads(json_output)

--- a/hmpps_person_match_score/views/person_match_view.py
+++ b/hmpps_person_match_score/views/person_match_view.py
@@ -60,6 +60,6 @@ class PersonMatchView(BaseView):
         json_output = prediction.as_pandas_dataframe().to_json()
 
         # manually clean up prediction table from db to avoid OOM, see PR 163
-        linker._delete_table_from_database(prediction.physical_name)
+        linker._delete_table_from_database(prediction.physical_name) # noqa: SLF001
 
         return json.loads(json_output)


### PR DESCRIPTION
This PR addresses an issue where the `person-match-score` service was consistently restarting due to exceeding its memory limits. The root cause is probably as a build-up of unused tables in DuckDB.

#### Issue

In our current setup, we maintain a single DuckDB connection that persists between API requests. This shared connection leads to a situation where tables created during various operations are not cleared, which eventually leads to memory exhaustion.

Deleting all tables using `linker.delete_tables_created_by_splink_from_db()` is not a viable solution, as it would interfere with other concurrent processes sharing the same connection and delete tables they're using

#### Solution

Below is a code example that illustrates the problem leading to the solution in this PR

<details>
<summary>Reprex: Memory Build-up Due to Unused Tables in DuckDB</summary>

```python
import duckdb
import pandas as pd

from splink.datasets import splink_datasets
from splink.duckdb.blocking_rule_library import block_on
from splink.duckdb.comparison_library import (
    exact_match,
    levenshtein_at_thresholds,
)
from splink.duckdb.linker import DuckDBLinker

df = splink_datasets.fake_1000

con = duckdb.connect()



settings = {
    "probability_two_random_records_match": 0.01,
    "link_type": "dedupe_only",
    "blocking_rules_to_generate_predictions": [
        block_on(["first_name"]),
        block_on(["surname"]),
    ],
    "comparisons": [
        levenshtein_at_thresholds("first_name", 2),
        exact_match("surname"),
        exact_match("dob"),
    ],
}


linker = DuckDBLinker(df, settings, connection=con)

predictions = linker.predict()

# There is now a table called predictions.physical_name
# in the Splink database that will persist forever unless deleted
# Here's how to delete it 
linker._delete_table_from_database(predictions.physical_name)

# See a list of tables currently in db
linker._intermediate_table_cache

# This method deletes everything including cached tf tables etc.
# so does 'too much'
linker.delete_tables_created_by_splink_from_db()

```

</details>

