### PR TITLE
CPR-79 Update python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     executor:
       name: hmpps/default
-      tag: 3.12.6
+      tag: 3.12.7
     steps:
       - checkout
       - run: poetry self update 1.8.2


### PR DESCRIPTION
* there is a version 3.13 but no `cimg` as of yet that supports it.