### PR TITLE
CPR-629 Fix existing event loop error

### DIFF
--- a/hmpps_person_match_score/utils/jwks.py
+++ b/hmpps_person_match_score/utils/jwks.py
@@ -65,8 +65,17 @@ class JWKS:
         Get the keys from the JWKS endpoint
         """
         if "keys" not in jwks_cache:
-            response = asyncio.run(
+            response = self._get_event_loop().run_until_complete(
                 RetryExecutor.retry(self._call_jwks_endpoint, retry_exceptions=self.RETRY_EXCEPTIONS),
             )
             jwks_cache["keys"] = response.json()["keys"]
         return jwks_cache["keys"]
+
+    @staticmethod
+    def _get_event_loop():
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        return loop


### PR DESCRIPTION
Fixes:
```
File "/usr/local/lib/python3.12/asyncio/runners.py", line 190, in run
raise RuntimeError(
RuntimeError: asyncio.run() cannot be called from a running event loop
```
Should use running event loop if exists else create one